### PR TITLE
updating kramer for better diagnostics

### DIFF
--- a/src/beetle-srv/Cargo.lock
+++ b/src/beetle-srv/Cargo.lock
@@ -1285,9 +1285,8 @@ dependencies = [
 
 [[package]]
 name = "kramer"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b666c6e449e88e36940c6e1bc986bd2f51429e4c0a8d6bb53f03e2d6d2ad8d44"
+version = "1.3.1"
+source = "git+https://github.com/sizethree/kramer.git?branch=readline-fix#ba2d55175fa3061d77c7eac3846755a63feeb4bf"
 dependencies = [
  "async-std",
 ]

--- a/src/beetle-srv/Cargo.toml
+++ b/src/beetle-srv/Cargo.toml
@@ -28,7 +28,7 @@ uuid = { version = "^1.0", features = ["v4"] }
 tide = { version = "^0.16" }
 async-std = { version = "^1.0", features = ["attributes"] }
 async-tls = { version = "^0.10" }
-kramer = { version = "^1.3", features = ["kramer-async", "acl"] }
+kramer = { git = "https://github.com/sizethree/kramer.git", branch = "readline-fix", features = ["kramer-async", "acl"] }
 chrono = { version = "^0.4" }
 serde = { version = "^1.0" }
 serde_json = { version = "^1.0" }


### PR DESCRIPTION
still tracking down an annoying redis problem; the [retry logic](https://github.com/dadleyy/orient-beetle/blob/5ca90bdc70f4ca98d39bfa69f8a83f46da876313/src/beetle-srv/src/api/worker.rs#L56-L98) in the worker is not behaving correctly. 

noticing in logs.